### PR TITLE
Defer/re-run the actions in case of failure

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "YouTube++",
   "short_name": "YTD",
   "description": "This extension shows the publishing or uploading date of related youtube videos in sidebar.",
-  "version": "2.2.6",
+  "version": "2.2.7",
 
   "icons": {
     "48": "image/icon48.png",


### PR DESCRIPTION
**Bug fix**
Using `run_at` `document_end` in the manifest is not enough. The 'Up Next' list
seems to load in later.

Based on errors noticed in the console log, code to handle the errors
and re-run `run_main_and_mutation` at an exponentially increasing interval
has been added.
The initial trigger on checking the window location is also deferred.

Here's some messages I saw in the console to make these changes:

> Error for video index  TypeError: Cannot read property 'children' of undefined
>     at main (main.js:130)
>     at run_main_and_mutation (main.js:98)
>     at main.js:171
> 

> Uncaught TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
>     at show_more_mutation (main.js:92)
>     at run_main_and_mutation (main.js:99)
>     at main.js:171
> 